### PR TITLE
Allow for using `python -m pyjs_code_runner.cli`

### DIFF
--- a/pyjs_code_runner/cli/__main__.py
+++ b/pyjs_code_runner/cli/__main__.py
@@ -1,0 +1,4 @@
+from .app import app
+
+if __name__ == "__main__":
+    app()

--- a/pyjs_code_runner/cli/main.py
+++ b/pyjs_code_runner/cli/main.py
@@ -1,9 +1,0 @@
-from .app import app
-from .run import *  # noqa: F401, F403
-from .version import *  # noqa: F401, F403
-
-if __name__ == "__main__":
-    from rich.console import Console
-
-    err_console = Console(stderr=True)
-    app(show_locals=False)

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(
     description="pyjs_code_runner emscripten+boa",
     entry_points={
         "console_scripts": [
-            "pyjs_code_runner=pyjs_code_runner.cli.main:app",
+            "pyjs_code_runner=pyjs_code_runner.cli.app:app",
         ],
     },
     install_requires=requirements,


### PR DESCRIPTION
This should allow for invoking the tool with ` `python -m pyjs_code_runner.cli`, which is also common for running Python applications.

